### PR TITLE
#14/feat : 고객을 생성하는 createCustomer함수 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'jakarta.validation:jakarta.validation-api:3.0.0'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'org.postgresql:postgresql'

--- a/src/main/java/dau/azit/simon/customer/controller/CustomerController.java
+++ b/src/main/java/dau/azit/simon/customer/controller/CustomerController.java
@@ -1,0 +1,10 @@
+package dau.azit.simon.customer.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/customers")
+public class CustomerController {
+	
+}

--- a/src/main/java/dau/azit/simon/customer/domain/Customer.java
+++ b/src/main/java/dau/azit/simon/customer/domain/Customer.java
@@ -1,0 +1,51 @@
+package dau.azit.simon.customer.domain;
+
+import dau.azit.simon.order.domain.Order;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.UUID;
+
+@Getter()
+@Entity(name = "customers")
+public class Customer {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false)
+	private UUID uid;
+
+	@Column(nullable = false)
+	String name;
+
+	String companyName;
+
+	String companyAddress;
+
+	@Column(nullable = false)
+	String contact;
+
+	@OneToMany()
+	@Column(nullable = false)
+	List<Order> orders;
+
+	String companyRepresentative;
+
+	public Customer() {
+	}
+
+	static public Customer createCustomer(String name, String contact, String companyName, String companyAddress, String companyRepresentative) {
+		return new Customer(name, contact, companyName, companyAddress, companyRepresentative);
+	}
+
+	private Customer(String name, String contact, String companyName, String companyAddress, String companyRepresentative) {
+		this.uid = UUID.randomUUID();
+		this.name = name;
+		this.companyName = companyName;
+		this.companyAddress = companyAddress;
+		this.contact = contact;
+		this.companyRepresentative = companyRepresentative;
+	}
+}

--- a/src/main/java/dau/azit/simon/customer/dto/CustomerDto.java
+++ b/src/main/java/dau/azit/simon/customer/dto/CustomerDto.java
@@ -1,0 +1,6 @@
+package dau.azit.simon.customer.dto;
+
+public class CustomerDto {
+	public record CreateCustomerDto(String name, String contact, String companyName, String companyAddress, String companyRepresentative) {
+	}
+}

--- a/src/main/java/dau/azit/simon/customer/repository/CustomerRepository.java
+++ b/src/main/java/dau/azit/simon/customer/repository/CustomerRepository.java
@@ -1,0 +1,8 @@
+package dau.azit.simon.customer.repository;
+
+import dau.azit.simon.customer.domain.Customer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CustomerRepository extends JpaRepository<Customer, Long> {
+
+}

--- a/src/main/java/dau/azit/simon/customer/service/CustomerService.java
+++ b/src/main/java/dau/azit/simon/customer/service/CustomerService.java
@@ -1,0 +1,21 @@
+package dau.azit.simon.customer.service;
+
+import dau.azit.simon.customer.domain.Customer;
+import dau.azit.simon.customer.dto.CustomerDto;
+import dau.azit.simon.customer.repository.CustomerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class CustomerService {
+	private final CustomerRepository customerRepository;
+
+	@Transactional
+	public Customer createCustomer(CustomerDto.CreateCustomerDto dto) {
+		Customer customer = Customer.createCustomer(dto.name(), dto.contact(), dto.companyName(), dto.companyAddress(), dto.companyRepresentative());
+		return customerRepository.save(customer);
+	}
+}

--- a/src/main/java/dau/azit/simon/order/controller/OrderController.java
+++ b/src/main/java/dau/azit/simon/order/controller/OrderController.java
@@ -1,0 +1,10 @@
+package dau.azit.simon.order.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/orders")
+public class OrderController {
+	
+}

--- a/src/main/java/dau/azit/simon/order/controller/OrderController.java
+++ b/src/main/java/dau/azit/simon/order/controller/OrderController.java
@@ -1,8 +1,12 @@
 package dau.azit.simon.order.controller;
 
+
+import dau.azit.simon.order.domain.Order;
 import dau.azit.simon.order.dto.OrderDto;
 import dau.azit.simon.order.service.OrderService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,8 +19,8 @@ public class OrderController {
 	private final OrderService orderService;
 
 	@PostMapping("/first")
-	public String createFirstOrder(@RequestBody() OrderDto.CreateFirstOrderDto createFirstOrderDto) {
-		return orderService.createFirstOrder(createFirstOrderDto).toString();
+	public ResponseEntity<Order> createFirstOrder(@Valid @RequestBody() OrderDto.CreateFirstOrderDto createFirstOrderDto) {
+		return ResponseEntity.ok(orderService.createFirstOrder(createFirstOrderDto));
 	}
 
 }

--- a/src/main/java/dau/azit/simon/order/controller/OrderController.java
+++ b/src/main/java/dau/azit/simon/order/controller/OrderController.java
@@ -1,10 +1,22 @@
 package dau.azit.simon.order.controller;
 
+import dau.azit.simon.order.dto.OrderDto;
+import dau.azit.simon.order.service.OrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/orders")
 public class OrderController {
-	
+	private final OrderService orderService;
+
+	@PostMapping("/first")
+	public String createFirstOrder(@RequestBody() OrderDto.CreateFirstOrderDto createFirstOrderDto) {
+		return orderService.createFirstOrder(createFirstOrderDto).toString();
+	}
+
 }

--- a/src/main/java/dau/azit/simon/order/domain/Order.java
+++ b/src/main/java/dau/azit/simon/order/domain/Order.java
@@ -40,6 +40,16 @@ public class Order {
 	public Order() {
 	}
 
+
+	static public Order createOrder(List<OrderLine> orderLines, Customer customer, String memo) {
+		return new Order(orderLines, customer, memo, OrderStatus.COMPLETE);
+	}
+
+	static public Order createEstimation(List<OrderLine> orderLines, Customer customer, String memo) {
+		return new Order(orderLines, customer, memo, OrderStatus.ESTIMATE);
+	}
+
+
 	private Order(List<OrderLine> orderLines, Customer customer, String memo, OrderStatus status) {
 		this.uid = UUID.randomUUID();
 		this.orderDate = new Date();

--- a/src/main/java/dau/azit/simon/order/domain/Order.java
+++ b/src/main/java/dau/azit/simon/order/domain/Order.java
@@ -1,6 +1,6 @@
 package dau.azit.simon.order.domain;
 
-import dau.azit.simon.order.domain.mock.Customer;
+import dau.azit.simon.customer.domain.Customer;
 import jakarta.persistence.*;
 import lombok.Getter;
 
@@ -30,7 +30,7 @@ public class Order {
 	@Enumerated(EnumType.STRING)
 	private OrderStatus status;
 
-	@OneToMany()
+	@OneToMany(cascade = CascadeType.PERSIST)
 	private List<OrderLine> orderLines;
 
 	// TODO : 실제 Customer 클래스로 수정 필요

--- a/src/main/java/dau/azit/simon/order/domain/Order.java
+++ b/src/main/java/dau/azit/simon/order/domain/Order.java
@@ -1,0 +1,44 @@
+package dau.azit.simon.order.domain;
+
+import jakarta.persistence.*;
+
+import java.util.Date;
+import java.util.UUID;
+
+@Entity
+public class Order {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false)
+	private UUID uid;
+
+	@Column(nullable = false)
+	private Date orderDate;
+
+	private String memo;
+
+	@Column(nullable = false)
+	private long totalPrice;
+
+	@Enumerated(EnumType.STRING)
+	private OrderStatus status;
+
+
+	public Order() {
+	}
+
+	private Order(String memo, long totalPrice, OrderStatus status) {
+		this.uid = UUID.randomUUID();
+		this.orderDate = new Date();
+		this.memo = memo;
+		this.totalPrice = totalPrice;
+		this.status = status;
+	}
+
+}
+
+enum OrderStatus {
+	ESTIMATE, COMPLETE
+}

--- a/src/main/java/dau/azit/simon/order/domain/Order.java
+++ b/src/main/java/dau/azit/simon/order/domain/Order.java
@@ -1,11 +1,16 @@
 package dau.azit.simon.order.domain;
 
+import dau.azit.simon.order.domain.mock.Customer;
 import jakarta.persistence.*;
+import lombok.Getter;
 
 import java.util.Date;
+import java.util.List;
 import java.util.UUID;
 
 @Entity
+@Table(name = "orders")
+@Getter
 public class Order {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -25,15 +30,23 @@ public class Order {
 	@Enumerated(EnumType.STRING)
 	private OrderStatus status;
 
+	@OneToMany()
+	private List<OrderLine> orderLines;
+
+	// TODO : 실제 Customer 클래스로 수정 필요
+	@ManyToOne()
+	private Customer customer;
 
 	public Order() {
 	}
 
-	private Order(String memo, long totalPrice, OrderStatus status) {
+	private Order(List<OrderLine> orderLines, Customer customer, String memo, OrderStatus status) {
 		this.uid = UUID.randomUUID();
 		this.orderDate = new Date();
 		this.memo = memo;
-		this.totalPrice = totalPrice;
+		this.orderLines = orderLines;
+		this.customer = customer;
+		this.totalPrice = orderLines.stream().mapToLong(OrderLine::getSalesPrice).sum();
 		this.status = status;
 	}
 

--- a/src/main/java/dau/azit/simon/order/domain/Order.java
+++ b/src/main/java/dau/azit/simon/order/domain/Order.java
@@ -41,12 +41,8 @@ public class Order {
 	}
 
 
-	static public Order createOrder(List<OrderLine> orderLines, Customer customer, String memo) {
-		return new Order(orderLines, customer, memo, OrderStatus.COMPLETE);
-	}
-
-	static public Order createEstimation(List<OrderLine> orderLines, Customer customer, String memo) {
-		return new Order(orderLines, customer, memo, OrderStatus.ESTIMATE);
+	static public Order createOrder(List<OrderLine> orderLines, Customer customer, OrderStatus orderStatus, String memo) {
+		return new Order(orderLines, customer, memo, orderStatus);
 	}
 
 
@@ -60,8 +56,4 @@ public class Order {
 		this.status = status;
 	}
 
-}
-
-enum OrderStatus {
-	ESTIMATE, COMPLETE
 }

--- a/src/main/java/dau/azit/simon/order/domain/OrderLine.java
+++ b/src/main/java/dau/azit/simon/order/domain/OrderLine.java
@@ -17,7 +17,8 @@ public class OrderLine {
 	@Column(nullable = false)
 	private UUID uid;
 
-	@OneToOne()
+	//TODO : 이후에 실제 Product 객체로 변경하면 cascade 부분 삭제 필요
+	@OneToOne(cascade = CascadeType.PERSIST)
 	private Product product;
 
 	@Column(nullable = false)

--- a/src/main/java/dau/azit/simon/order/domain/OrderLine.java
+++ b/src/main/java/dau/azit/simon/order/domain/OrderLine.java
@@ -2,10 +2,13 @@ package dau.azit.simon.order.domain;
 
 import dau.azit.simon.order.domain.mock.Product;
 import jakarta.persistence.*;
+import lombok.Getter;
 
 import java.util.UUID;
 
 @Entity
+@Getter
+@Table(name = "orderLines")
 public class OrderLine {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/dau/azit/simon/order/domain/OrderLine.java
+++ b/src/main/java/dau/azit/simon/order/domain/OrderLine.java
@@ -1,0 +1,37 @@
+package dau.azit.simon.order.domain;
+
+import dau.azit.simon.order.domain.mock.Product;
+import jakarta.persistence.*;
+
+import java.util.UUID;
+
+@Entity
+public class OrderLine {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false)
+	private UUID uid;
+
+	@OneToOne()
+	private Product product;
+
+	@Column(nullable = false)
+	int quantity;
+
+	@Column(nullable = false)
+	int salesPrice;
+
+	public OrderLine(Product product, int quantity) {
+		this.uid = UUID.randomUUID();
+		this.product = product;
+		this.quantity = quantity;
+
+		// TODO : 실제 Product 클래스로 수정 필요
+		this.salesPrice = this.product.getPrice() * quantity;
+	}
+
+	public OrderLine() {
+	}
+}

--- a/src/main/java/dau/azit/simon/order/domain/OrderStatus.java
+++ b/src/main/java/dau/azit/simon/order/domain/OrderStatus.java
@@ -1,0 +1,6 @@
+package dau.azit.simon.order.domain;
+
+public enum OrderStatus {
+	ESTIMATE, COMPLETE
+}
+

--- a/src/main/java/dau/azit/simon/order/domain/mock/Customer.java
+++ b/src/main/java/dau/azit/simon/order/domain/mock/Customer.java
@@ -1,0 +1,11 @@
+package dau.azit.simon.order.domain.mock;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity()
+public class Customer {
+	@Id
+	private Long id;
+
+}

--- a/src/main/java/dau/azit/simon/order/domain/mock/Product.java
+++ b/src/main/java/dau/azit/simon/order/domain/mock/Product.java
@@ -1,11 +1,14 @@
 package dau.azit.simon.order.domain.mock;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 
 @Entity()
 public class Product {
 	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
 	public int getPrice() {

--- a/src/main/java/dau/azit/simon/order/domain/mock/Product.java
+++ b/src/main/java/dau/azit/simon/order/domain/mock/Product.java
@@ -1,0 +1,14 @@
+package dau.azit.simon.order.domain.mock;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+@Entity()
+public class Product {
+	@Id
+	private Long id;
+
+	public int getPrice() {
+		return 1000;
+	}
+}

--- a/src/main/java/dau/azit/simon/order/dto/OrderDto.java
+++ b/src/main/java/dau/azit/simon/order/dto/OrderDto.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 public class OrderDto {
 
-	public record CreateOrderDto(List<OrderLine> orderLines, Long customerId, Optional<String> memo) {
+	public record CreateOrderDto(List<OrderLineDto> orderLines, Long customerId, Optional<String> memo) {
 	}
 
 	public record OrderLineDto(Long productId, int quantity) {

--- a/src/main/java/dau/azit/simon/order/dto/OrderDto.java
+++ b/src/main/java/dau/azit/simon/order/dto/OrderDto.java
@@ -1,0 +1,17 @@
+package dau.azit.simon.order.dto;
+
+
+import dau.azit.simon.order.domain.OrderLine;
+
+import java.util.List;
+import java.util.Optional;
+
+public class OrderDto {
+
+	public record CreateOrderDto(List<OrderLine> orderLines, Long customerId, Optional<String> memo) {
+	}
+
+	public record OrderLineDto(Long productId, int quantity) {
+	}
+
+}

--- a/src/main/java/dau/azit/simon/order/dto/OrderDto.java
+++ b/src/main/java/dau/azit/simon/order/dto/OrderDto.java
@@ -1,14 +1,19 @@
 package dau.azit.simon.order.dto;
 
-
-import dau.azit.simon.order.domain.OrderLine;
+import dau.azit.simon.customer.dto.CustomerDto;
 
 import java.util.List;
 import java.util.Optional;
 
-public class OrderDto {
+public record OrderDto() {
 
 	public record CreateAdditionalOrderDto(List<OrderLineDto> orderLines, Long customerId, Optional<String> memo) {
+	}
+
+	public record CreateFirstOrderDto(CustomerDto.CreateCustomerDto customer,
+	                                  List<OrderLineDto> orderLines,
+	                                  Optional<String> memo
+	) {
 	}
 
 	public record OrderLineDto(Long productId, int quantity) {

--- a/src/main/java/dau/azit/simon/order/dto/OrderDto.java
+++ b/src/main/java/dau/azit/simon/order/dto/OrderDto.java
@@ -1,17 +1,22 @@
 package dau.azit.simon.order.dto;
 
 import dau.azit.simon.customer.dto.CustomerDto;
+import dau.azit.simon.order.domain.OrderStatus;
+import lombok.NonNull;
 
 import java.util.List;
 import java.util.Optional;
 
 public record OrderDto() {
 
-	public record CreateAdditionalOrderDto(List<OrderLineDto> orderLines, Long customerId, Optional<String> memo) {
+	public record CreateAdditionalOrderDto(List<OrderLineDto> orderLines, Long customerId, OrderStatus orderStatus,
+	                                       Optional<String> memo) {
 	}
 
 	public record CreateFirstOrderDto(CustomerDto.CreateCustomerDto customer,
 	                                  List<OrderLineDto> orderLines,
+	                                  @NonNull()
+	                                  OrderStatus orderStatus,
 	                                  Optional<String> memo
 	) {
 	}

--- a/src/main/java/dau/azit/simon/order/dto/OrderDto.java
+++ b/src/main/java/dau/azit/simon/order/dto/OrderDto.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 public class OrderDto {
 
-	public record CreateOrderDto(List<OrderLineDto> orderLines, Long customerId, Optional<String> memo) {
+	public record CreateAdditionalOrderDto(List<OrderLineDto> orderLines, Long customerId, Optional<String> memo) {
 	}
 
 	public record OrderLineDto(Long productId, int quantity) {

--- a/src/main/java/dau/azit/simon/order/repository/OrderRepository.java
+++ b/src/main/java/dau/azit/simon/order/repository/OrderRepository.java
@@ -1,0 +1,9 @@
+package dau.azit.simon.order.repository;
+
+
+import dau.azit.simon.order.domain.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+
+}

--- a/src/main/java/dau/azit/simon/order/service/OrderService.java
+++ b/src/main/java/dau/azit/simon/order/service/OrderService.java
@@ -7,9 +7,7 @@ import dau.azit.simon.order.domain.OrderLine;
 import dau.azit.simon.order.domain.mock.Product;
 import dau.azit.simon.order.dto.OrderDto;
 import dau.azit.simon.order.repository.OrderRepository;
-import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,7 +33,7 @@ public class OrderService {
 				})
 				.collect(Collectors.toList());
 
-		Order order = Order.createOrder(orderLines, customer, dto.memo().orElse(null));
+		Order order = Order.createOrder(orderLines, customer, dto.orderStatus(), dto.memo().orElse(null));
 
 		return orderRepository.save(order);
 	}
@@ -56,7 +54,7 @@ public class OrderService {
 				})
 				.collect(Collectors.toList());
 //
-		Order order = Order.createOrder(orderLines, customer, dto.memo().orElse(null));
+		Order order = Order.createOrder(orderLines, customer, dto.orderStatus(), dto.memo().orElse(null));
 
 		return orderRepository.save(order);
 //	}

--- a/src/main/java/dau/azit/simon/order/service/OrderService.java
+++ b/src/main/java/dau/azit/simon/order/service/OrderService.java
@@ -1,21 +1,27 @@
 package dau.azit.simon.order.service;
 
+import dau.azit.simon.customer.domain.Customer;
+import dau.azit.simon.customer.service.CustomerService;
 import dau.azit.simon.order.domain.Order;
 import dau.azit.simon.order.domain.OrderLine;
-import dau.azit.simon.order.domain.mock.Customer;
 import dau.azit.simon.order.domain.mock.Product;
 import dau.azit.simon.order.dto.OrderDto;
 import dau.azit.simon.order.repository.OrderRepository;
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
+@Service
 @Transactional(readOnly = true)
 public class OrderService {
 	private final OrderRepository orderRepository;
+	private final CustomerService customerService;
 
 	public Order createAdditionalOrder(OrderDto.CreateAdditionalOrderDto dto) {
 		//TODO : 실제 Customer 클래스로 수정 필요
@@ -32,6 +38,28 @@ public class OrderService {
 		Order order = Order.createOrder(orderLines, customer, dto.memo().orElse(null));
 
 		return orderRepository.save(order);
+	}
+
+
+	@Transactional
+	public Order createFirstOrder(OrderDto.CreateFirstOrderDto dto) {
+		if (dto.customer() == null || dto.orderLines() == null) {
+			throw new IllegalArgumentException("customer or orderLines is null");
+		}
+
+		Customer customer = customerService.createCustomer(dto.customer());
+		List<OrderLine> orderLines = dto.orderLines().stream()
+				.map(orderLineDto -> {
+					//TODO : 실제 Product 클래스로 수정 필요
+					Product product = new Product();
+					return new OrderLine(product, orderLineDto.quantity());
+				})
+				.collect(Collectors.toList());
+//
+		Order order = Order.createOrder(orderLines, customer, dto.memo().orElse(null));
+
+		return orderRepository.save(order);
+//	}
 	}
 
 

--- a/src/main/java/dau/azit/simon/order/service/OrderService.java
+++ b/src/main/java/dau/azit/simon/order/service/OrderService.java
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
 public class OrderService {
 	private final OrderRepository orderRepository;
 
-	public Order createOrder(OrderDto.CreateOrderDto dto) {
+	public Order createAdditionalOrder(OrderDto.CreateAdditionalOrderDto dto) {
 		//TODO : 실제 Customer 클래스로 수정 필요
 		Customer customer = new Customer();
 
@@ -34,21 +34,5 @@ public class OrderService {
 		return orderRepository.save(order);
 	}
 
-	public Order createEstimation(OrderDto.CreateOrderDto dto) {
-		//TODO : 실제 Customer 클래스로 수정 필요
-		Customer customer = new Customer();
-
-		List<OrderLine> orderLines = dto.orderLines().stream()
-				.map(orderLineDto -> {
-					//TODO : 실제 Product 클래스로 수정 필요
-					Product product = new Product();
-					return new OrderLine(product, orderLineDto.quantity());
-				})
-				.collect(Collectors.toList());
-
-		Order order = Order.createEstimation(orderLines, customer, dto.memo().orElse(null));
-
-		return orderRepository.save(order);
-	}
 
 }

--- a/src/main/java/dau/azit/simon/order/service/OrderService.java
+++ b/src/main/java/dau/azit/simon/order/service/OrderService.java
@@ -1,12 +1,54 @@
 package dau.azit.simon.order.service;
 
+import dau.azit.simon.order.domain.Order;
+import dau.azit.simon.order.domain.OrderLine;
+import dau.azit.simon.order.domain.mock.Customer;
+import dau.azit.simon.order.domain.mock.Product;
+import dau.azit.simon.order.dto.OrderDto;
 import dau.azit.simon.order.repository.OrderRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class OrderService {
 	private final OrderRepository orderRepository;
+
+	public Order createOrder(OrderDto.CreateOrderDto dto) {
+		//TODO : 실제 Customer 클래스로 수정 필요
+		Customer customer = new Customer();
+
+		List<OrderLine> orderLines = dto.orderLines().stream()
+				.map(orderLineDto -> {
+					//TODO : 실제 Product 클래스로 수정 필요
+					Product product = new Product();
+					return new OrderLine(product, orderLineDto.getQuantity());
+				})
+				.collect(Collectors.toList());
+
+		Order order = Order.createOrder(orderLines, customer, dto.memo().orElse(null));
+
+		return orderRepository.save(order);
+	}
+
+	public Order createEstimation(OrderDto.CreateOrderDto dto) {
+		//TODO : 실제 Customer 클래스로 수정 필요
+		Customer customer = new Customer();
+
+		List<OrderLine> orderLines = dto.orderLines().stream()
+				.map(orderLineDto -> {
+					//TODO : 실제 Product 클래스로 수정 필요
+					Product product = new Product();
+					return new OrderLine(product, orderLineDto.getQuantity());
+				})
+				.collect(Collectors.toList());
+
+		Order order = Order.createEstimation(orderLines, customer, dto.memo().orElse(null));
+
+		return orderRepository.save(order);
+	}
 
 }

--- a/src/main/java/dau/azit/simon/order/service/OrderService.java
+++ b/src/main/java/dau/azit/simon/order/service/OrderService.java
@@ -1,0 +1,12 @@
+package dau.azit.simon.order.service;
+
+import dau.azit.simon.order.repository.OrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OrderService {
+	private final OrderRepository orderRepository;
+
+}

--- a/src/main/java/dau/azit/simon/order/service/OrderService.java
+++ b/src/main/java/dau/azit/simon/order/service/OrderService.java
@@ -25,7 +25,7 @@ public class OrderService {
 				.map(orderLineDto -> {
 					//TODO : 실제 Product 클래스로 수정 필요
 					Product product = new Product();
-					return new OrderLine(product, orderLineDto.getQuantity());
+					return new OrderLine(product, orderLineDto.quantity());
 				})
 				.collect(Collectors.toList());
 
@@ -42,7 +42,7 @@ public class OrderService {
 				.map(orderLineDto -> {
 					//TODO : 실제 Product 클래스로 수정 필요
 					Product product = new Product();
-					return new OrderLine(product, orderLineDto.getQuantity());
+					return new OrderLine(product, orderLineDto.quantity());
 				})
 				.collect(Collectors.toList());
 


### PR DESCRIPTION
- 기본적인 Service, Repository, Controller, Dto 구현.
- 고객은 항상 주문과 같이 들어온다는 비즈니스 문맥을 고려하여 현재 createCustomer는 OrderService에서 사용되고 있고 customer만을 따로 만드는 api를 컨트롤러에 따로 작성하지는 않음.
- 만약 고객만 따로 추가하는 로직이 필요할 경우 추후에 구현할 예정임.