### PR TITLE
feat : Customer의 엔티티와 기본 골격, Order의 기본적인 create로직 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'jakarta.validation:jakarta.validation-api:3.0.0'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'org.postgresql:postgresql'

--- a/src/main/java/dau/azit/simon/customer/controller/CustomerController.java
+++ b/src/main/java/dau/azit/simon/customer/controller/CustomerController.java
@@ -1,0 +1,10 @@
+package dau.azit.simon.customer.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/customers")
+public class CustomerController {
+	
+}

--- a/src/main/java/dau/azit/simon/customer/domain/Customer.java
+++ b/src/main/java/dau/azit/simon/customer/domain/Customer.java
@@ -1,6 +1,6 @@
 package dau.azit.simon.customer.domain;
 
-import dau.azit.simon.order.domain.Order;
+import dau.azit.simon.order.domain.SalesOrder;
 import jakarta.persistence.*;
 import lombok.Getter;
 
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.UUID;
 
 @Getter()
-@Entity(name = "customers")
+@Entity(name = "customer")
 public class Customer {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -29,7 +29,7 @@ public class Customer {
 
 	@OneToMany()
 	@Column(nullable = false)
-	List<Order> orders;
+	List<SalesOrder> orders;
 
 	String companyRepresentative;
 

--- a/src/main/java/dau/azit/simon/customer/domain/Customer.java
+++ b/src/main/java/dau/azit/simon/customer/domain/Customer.java
@@ -1,0 +1,51 @@
+package dau.azit.simon.customer.domain;
+
+import dau.azit.simon.order.domain.Order;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.util.List;
+import java.util.UUID;
+
+@Getter()
+@Entity(name = "customers")
+public class Customer {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false)
+	private UUID uid;
+
+	@Column(nullable = false)
+	String name;
+
+	String companyName;
+
+	String companyAddress;
+
+	@Column(nullable = false)
+	String contact;
+
+	@OneToMany()
+	@Column(nullable = false)
+	List<Order> orders;
+
+	String companyRepresentative;
+
+	public Customer() {
+	}
+
+	static public Customer createCustomer(String name, String contact, String companyName, String companyAddress, String companyRepresentative) {
+		return new Customer(name, contact, companyName, companyAddress, companyRepresentative);
+	}
+
+	private Customer(String name, String contact, String companyName, String companyAddress, String companyRepresentative) {
+		this.uid = UUID.randomUUID();
+		this.name = name;
+		this.companyName = companyName;
+		this.companyAddress = companyAddress;
+		this.contact = contact;
+		this.companyRepresentative = companyRepresentative;
+	}
+}

--- a/src/main/java/dau/azit/simon/customer/dto/CustomerDto.java
+++ b/src/main/java/dau/azit/simon/customer/dto/CustomerDto.java
@@ -1,0 +1,6 @@
+package dau.azit.simon.customer.dto;
+
+public class CustomerDto {
+	public record CreateCustomerDto(String name, String contact, String companyName, String companyAddress, String companyRepresentative) {
+	}
+}

--- a/src/main/java/dau/azit/simon/customer/repository/CustomerRepository.java
+++ b/src/main/java/dau/azit/simon/customer/repository/CustomerRepository.java
@@ -1,0 +1,8 @@
+package dau.azit.simon.customer.repository;
+
+import dau.azit.simon.customer.domain.Customer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CustomerRepository extends JpaRepository<Customer, Long> {
+
+}

--- a/src/main/java/dau/azit/simon/customer/service/CustomerService.java
+++ b/src/main/java/dau/azit/simon/customer/service/CustomerService.java
@@ -18,4 +18,8 @@ public class CustomerService {
 		Customer customer = Customer.createCustomer(dto.name(), dto.contact(), dto.companyName(), dto.companyAddress(), dto.companyRepresentative());
 		return customerRepository.save(customer);
 	}
+
+	public Customer findCustomerById(Long customerId) {
+		return customerRepository.findById(customerId).orElseThrow(() -> new IllegalArgumentException("customer not found"));
+	}
 }

--- a/src/main/java/dau/azit/simon/customer/service/CustomerService.java
+++ b/src/main/java/dau/azit/simon/customer/service/CustomerService.java
@@ -1,0 +1,21 @@
+package dau.azit.simon.customer.service;
+
+import dau.azit.simon.customer.domain.Customer;
+import dau.azit.simon.customer.dto.CustomerDto;
+import dau.azit.simon.customer.repository.CustomerRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class CustomerService {
+	private final CustomerRepository customerRepository;
+
+	@Transactional
+	public Customer createCustomer(CustomerDto.CreateCustomerDto dto) {
+		Customer customer = Customer.createCustomer(dto.name(), dto.contact(), dto.companyName(), dto.companyAddress(), dto.companyRepresentative());
+		return customerRepository.save(customer);
+	}
+}

--- a/src/main/java/dau/azit/simon/order/controller/OrderController.java
+++ b/src/main/java/dau/azit/simon/order/controller/OrderController.java
@@ -1,0 +1,10 @@
+package dau.azit.simon.order.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/orders")
+public class OrderController {
+	
+}

--- a/src/main/java/dau/azit/simon/order/controller/OrderController.java
+++ b/src/main/java/dau/azit/simon/order/controller/OrderController.java
@@ -1,8 +1,12 @@
 package dau.azit.simon.order.controller;
 
+
+import dau.azit.simon.order.domain.Order;
 import dau.azit.simon.order.dto.OrderDto;
 import dau.azit.simon.order.service.OrderService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,8 +19,8 @@ public class OrderController {
 	private final OrderService orderService;
 
 	@PostMapping("/first")
-	public String createFirstOrder(@RequestBody() OrderDto.CreateFirstOrderDto createFirstOrderDto) {
-		return orderService.createFirstOrder(createFirstOrderDto).toString();
+	public ResponseEntity<Order> createFirstOrder(@Valid @RequestBody() OrderDto.CreateFirstOrderDto createFirstOrderDto) {
+		return ResponseEntity.ok(orderService.createFirstOrder(createFirstOrderDto));
 	}
 
 }

--- a/src/main/java/dau/azit/simon/order/controller/OrderController.java
+++ b/src/main/java/dau/azit/simon/order/controller/OrderController.java
@@ -23,4 +23,9 @@ public class OrderController {
 		return ResponseEntity.ok(orderService.createFirstOrder(createFirstOrderDto));
 	}
 
+	@PostMapping("/additional")
+	public ResponseEntity<Order> createAdditionalOrder(@Valid @RequestBody() OrderDto.CreateAdditionalOrderDto dto) {
+		orderService.createAdditionalOrder(dto);
+		return ResponseEntity.ok(null);
+	}
 }

--- a/src/main/java/dau/azit/simon/order/controller/OrderController.java
+++ b/src/main/java/dau/azit/simon/order/controller/OrderController.java
@@ -17,12 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/orders")
 public class OrderController {
 	private final OrderService orderService;
-
-	@PostMapping("/first")
-	public ResponseEntity<SalesOrder> createFirstOrder(@Valid @RequestBody() OrderDto.CreateFirstOrderDto createFirstOrderDto) {
-		return ResponseEntity.ok(orderService.createFirstOrder(createFirstOrderDto));
-	}
-
+	
 	@PostMapping("/additional")
 	public ResponseEntity<SalesOrder> createAdditionalOrder(@Valid @RequestBody() OrderDto.CreateAdditionalOrderDto dto) {
 		orderService.createAdditionalOrder(dto);

--- a/src/main/java/dau/azit/simon/order/controller/OrderController.java
+++ b/src/main/java/dau/azit/simon/order/controller/OrderController.java
@@ -1,10 +1,22 @@
 package dau.azit.simon.order.controller;
 
+import dau.azit.simon.order.dto.OrderDto;
+import dau.azit.simon.order.service.OrderService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/orders")
 public class OrderController {
-	
+	private final OrderService orderService;
+
+	@PostMapping("/first")
+	public String createFirstOrder(@RequestBody() OrderDto.CreateFirstOrderDto createFirstOrderDto) {
+		return orderService.createFirstOrder(createFirstOrderDto).toString();
+	}
+
 }

--- a/src/main/java/dau/azit/simon/order/controller/OrderController.java
+++ b/src/main/java/dau/azit/simon/order/controller/OrderController.java
@@ -1,7 +1,7 @@
 package dau.azit.simon.order.controller;
 
 
-import dau.azit.simon.order.domain.Order;
+import dau.azit.simon.order.domain.SalesOrder;
 import dau.azit.simon.order.dto.OrderDto;
 import dau.azit.simon.order.service.OrderService;
 import jakarta.validation.Valid;
@@ -19,12 +19,12 @@ public class OrderController {
 	private final OrderService orderService;
 
 	@PostMapping("/first")
-	public ResponseEntity<Order> createFirstOrder(@Valid @RequestBody() OrderDto.CreateFirstOrderDto createFirstOrderDto) {
+	public ResponseEntity<SalesOrder> createFirstOrder(@Valid @RequestBody() OrderDto.CreateFirstOrderDto createFirstOrderDto) {
 		return ResponseEntity.ok(orderService.createFirstOrder(createFirstOrderDto));
 	}
 
 	@PostMapping("/additional")
-	public ResponseEntity<Order> createAdditionalOrder(@Valid @RequestBody() OrderDto.CreateAdditionalOrderDto dto) {
+	public ResponseEntity<SalesOrder> createAdditionalOrder(@Valid @RequestBody() OrderDto.CreateAdditionalOrderDto dto) {
 		orderService.createAdditionalOrder(dto);
 		return ResponseEntity.ok(null);
 	}

--- a/src/main/java/dau/azit/simon/order/domain/Order.java
+++ b/src/main/java/dau/azit/simon/order/domain/Order.java
@@ -33,7 +33,6 @@ public class Order {
 	@OneToMany(cascade = CascadeType.PERSIST)
 	private List<OrderLine> orderLines;
 
-	// TODO : 실제 Customer 클래스로 수정 필요
 	@ManyToOne()
 	private Customer customer;
 
@@ -41,7 +40,7 @@ public class Order {
 	}
 
 
-	static public Order createOrder(List<OrderLine> orderLines, Customer customer, OrderStatus orderStatus, String memo) {
+	public static Order createOrder(List<OrderLine> orderLines, Customer customer, OrderStatus orderStatus, String memo) {
 		return new Order(orderLines, customer, memo, orderStatus);
 	}
 

--- a/src/main/java/dau/azit/simon/order/domain/Order.java
+++ b/src/main/java/dau/azit/simon/order/domain/Order.java
@@ -40,6 +40,16 @@ public class Order {
 	public Order() {
 	}
 
+
+	static public Order createOrder(List<OrderLine> orderLines, Customer customer, String memo) {
+		return new Order(orderLines, customer, memo, OrderStatus.COMPLETE);
+	}
+
+	static public Order createEstimation(List<OrderLine> orderLines, Customer customer, String memo) {
+		return new Order(orderLines, customer, memo, OrderStatus.ESTIMATE);
+	}
+
+
 	private Order(List<OrderLine> orderLines, Customer customer, String memo, OrderStatus status) {
 		this.uid = UUID.randomUUID();
 		this.orderDate = new Date();

--- a/src/main/java/dau/azit/simon/order/domain/Order.java
+++ b/src/main/java/dau/azit/simon/order/domain/Order.java
@@ -1,6 +1,6 @@
 package dau.azit.simon.order.domain;
 
-import dau.azit.simon.order.domain.mock.Customer;
+import dau.azit.simon.customer.domain.Customer;
 import jakarta.persistence.*;
 import lombok.Getter;
 
@@ -30,7 +30,7 @@ public class Order {
 	@Enumerated(EnumType.STRING)
 	private OrderStatus status;
 
-	@OneToMany()
+	@OneToMany(cascade = CascadeType.PERSIST)
 	private List<OrderLine> orderLines;
 
 	// TODO : 실제 Customer 클래스로 수정 필요

--- a/src/main/java/dau/azit/simon/order/domain/Order.java
+++ b/src/main/java/dau/azit/simon/order/domain/Order.java
@@ -41,12 +41,8 @@ public class Order {
 	}
 
 
-	static public Order createOrder(List<OrderLine> orderLines, Customer customer, String memo) {
-		return new Order(orderLines, customer, memo, OrderStatus.COMPLETE);
-	}
-
-	static public Order createEstimation(List<OrderLine> orderLines, Customer customer, String memo) {
-		return new Order(orderLines, customer, memo, OrderStatus.ESTIMATE);
+	static public Order createOrder(List<OrderLine> orderLines, Customer customer, OrderStatus orderStatus, String memo) {
+		return new Order(orderLines, customer, memo, orderStatus);
 	}
 
 
@@ -60,8 +56,4 @@ public class Order {
 		this.status = status;
 	}
 
-}
-
-enum OrderStatus {
-	ESTIMATE, COMPLETE
 }

--- a/src/main/java/dau/azit/simon/order/domain/OrderLine.java
+++ b/src/main/java/dau/azit/simon/order/domain/OrderLine.java
@@ -17,7 +17,8 @@ public class OrderLine {
 	@Column(nullable = false)
 	private UUID uid;
 
-	@OneToOne()
+	//TODO : 이후에 실제 Product 객체로 변경하면 cascade 부분 삭제 필요
+	@OneToOne(cascade = CascadeType.PERSIST)
 	private Product product;
 
 	@Column(nullable = false)

--- a/src/main/java/dau/azit/simon/order/domain/OrderStatus.java
+++ b/src/main/java/dau/azit/simon/order/domain/OrderStatus.java
@@ -1,0 +1,6 @@
+package dau.azit.simon.order.domain;
+
+public enum OrderStatus {
+	ESTIMATE, COMPLETE
+}
+

--- a/src/main/java/dau/azit/simon/order/domain/SalesOrder.java
+++ b/src/main/java/dau/azit/simon/order/domain/SalesOrder.java
@@ -9,9 +9,9 @@ import java.util.List;
 import java.util.UUID;
 
 @Entity
-@Table(name = "orders")
+@Table(name = "sales_order")
 @Getter
-public class Order {
+public class SalesOrder {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
@@ -36,16 +36,16 @@ public class Order {
 	@ManyToOne()
 	private Customer customer;
 
-	public Order() {
+	public SalesOrder() {
 	}
 
 
-	public static Order createOrder(List<OrderLine> orderLines, Customer customer, OrderStatus orderStatus, String memo) {
-		return new Order(orderLines, customer, memo, orderStatus);
+	public static SalesOrder createOrder(List<OrderLine> orderLines, Customer customer, OrderStatus orderStatus, String memo) {
+		return new SalesOrder(orderLines, customer, memo, orderStatus);
 	}
 
 
-	private Order(List<OrderLine> orderLines, Customer customer, String memo, OrderStatus status) {
+	private SalesOrder(List<OrderLine> orderLines, Customer customer, String memo, OrderStatus status) {
 		this.uid = UUID.randomUUID();
 		this.orderDate = new Date();
 		this.memo = memo;

--- a/src/main/java/dau/azit/simon/order/domain/mock/Product.java
+++ b/src/main/java/dau/azit/simon/order/domain/mock/Product.java
@@ -1,11 +1,14 @@
 package dau.azit.simon.order.domain.mock;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 
 @Entity()
 public class Product {
 	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
 	public int getPrice() {

--- a/src/main/java/dau/azit/simon/order/dto/OrderDto.java
+++ b/src/main/java/dau/azit/simon/order/dto/OrderDto.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 public class OrderDto {
 
-	public record CreateOrderDto(List<OrderLine> orderLines, Long customerId, Optional<String> memo) {
+	public record CreateOrderDto(List<OrderLineDto> orderLines, Long customerId, Optional<String> memo) {
 	}
 
 	public record OrderLineDto(Long productId, int quantity) {

--- a/src/main/java/dau/azit/simon/order/dto/OrderDto.java
+++ b/src/main/java/dau/azit/simon/order/dto/OrderDto.java
@@ -1,0 +1,17 @@
+package dau.azit.simon.order.dto;
+
+
+import dau.azit.simon.order.domain.OrderLine;
+
+import java.util.List;
+import java.util.Optional;
+
+public class OrderDto {
+
+	public record CreateOrderDto(List<OrderLine> orderLines, Long customerId, Optional<String> memo) {
+	}
+
+	public record OrderLineDto(Long productId, int quantity) {
+	}
+
+}

--- a/src/main/java/dau/azit/simon/order/dto/OrderDto.java
+++ b/src/main/java/dau/azit/simon/order/dto/OrderDto.java
@@ -1,14 +1,19 @@
 package dau.azit.simon.order.dto;
 
-
-import dau.azit.simon.order.domain.OrderLine;
+import dau.azit.simon.customer.dto.CustomerDto;
 
 import java.util.List;
 import java.util.Optional;
 
-public class OrderDto {
+public record OrderDto() {
 
 	public record CreateAdditionalOrderDto(List<OrderLineDto> orderLines, Long customerId, Optional<String> memo) {
+	}
+
+	public record CreateFirstOrderDto(CustomerDto.CreateCustomerDto customer,
+	                                  List<OrderLineDto> orderLines,
+	                                  Optional<String> memo
+	) {
 	}
 
 	public record OrderLineDto(Long productId, int quantity) {

--- a/src/main/java/dau/azit/simon/order/dto/OrderDto.java
+++ b/src/main/java/dau/azit/simon/order/dto/OrderDto.java
@@ -1,17 +1,22 @@
 package dau.azit.simon.order.dto;
 
 import dau.azit.simon.customer.dto.CustomerDto;
+import dau.azit.simon.order.domain.OrderStatus;
+import lombok.NonNull;
 
 import java.util.List;
 import java.util.Optional;
 
 public record OrderDto() {
 
-	public record CreateAdditionalOrderDto(List<OrderLineDto> orderLines, Long customerId, Optional<String> memo) {
+	public record CreateAdditionalOrderDto(List<OrderLineDto> orderLines, Long customerId, OrderStatus orderStatus,
+	                                       Optional<String> memo) {
 	}
 
 	public record CreateFirstOrderDto(CustomerDto.CreateCustomerDto customer,
 	                                  List<OrderLineDto> orderLines,
+	                                  @NonNull()
+	                                  OrderStatus orderStatus,
 	                                  Optional<String> memo
 	) {
 	}

--- a/src/main/java/dau/azit/simon/order/dto/OrderDto.java
+++ b/src/main/java/dau/azit/simon/order/dto/OrderDto.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 public class OrderDto {
 
-	public record CreateOrderDto(List<OrderLineDto> orderLines, Long customerId, Optional<String> memo) {
+	public record CreateAdditionalOrderDto(List<OrderLineDto> orderLines, Long customerId, Optional<String> memo) {
 	}
 
 	public record OrderLineDto(Long productId, int quantity) {

--- a/src/main/java/dau/azit/simon/order/repository/OrderRepository.java
+++ b/src/main/java/dau/azit/simon/order/repository/OrderRepository.java
@@ -1,0 +1,9 @@
+package dau.azit.simon.order.repository;
+
+
+import dau.azit.simon.order.domain.Order;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OrderRepository extends JpaRepository<Order, Long> {
+
+}

--- a/src/main/java/dau/azit/simon/order/repository/OrderRepository.java
+++ b/src/main/java/dau/azit/simon/order/repository/OrderRepository.java
@@ -1,9 +1,9 @@
 package dau.azit.simon.order.repository;
 
 
-import dau.azit.simon.order.domain.Order;
+import dau.azit.simon.order.domain.SalesOrder;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface OrderRepository extends JpaRepository<Order, Long> {
+public interface OrderRepository extends JpaRepository<SalesOrder, Long> {
 
 }

--- a/src/main/java/dau/azit/simon/order/service/OrderService.java
+++ b/src/main/java/dau/azit/simon/order/service/OrderService.java
@@ -7,9 +7,7 @@ import dau.azit.simon.order.domain.OrderLine;
 import dau.azit.simon.order.domain.mock.Product;
 import dau.azit.simon.order.dto.OrderDto;
 import dau.azit.simon.order.repository.OrderRepository;
-import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,7 +33,7 @@ public class OrderService {
 				})
 				.collect(Collectors.toList());
 
-		Order order = Order.createOrder(orderLines, customer, dto.memo().orElse(null));
+		Order order = Order.createOrder(orderLines, customer, dto.orderStatus(), dto.memo().orElse(null));
 
 		return orderRepository.save(order);
 	}
@@ -56,7 +54,7 @@ public class OrderService {
 				})
 				.collect(Collectors.toList());
 //
-		Order order = Order.createOrder(orderLines, customer, dto.memo().orElse(null));
+		Order order = Order.createOrder(orderLines, customer, dto.orderStatus(), dto.memo().orElse(null));
 
 		return orderRepository.save(order);
 //	}

--- a/src/main/java/dau/azit/simon/order/service/OrderService.java
+++ b/src/main/java/dau/azit/simon/order/service/OrderService.java
@@ -1,21 +1,27 @@
 package dau.azit.simon.order.service;
 
+import dau.azit.simon.customer.domain.Customer;
+import dau.azit.simon.customer.service.CustomerService;
 import dau.azit.simon.order.domain.Order;
 import dau.azit.simon.order.domain.OrderLine;
-import dau.azit.simon.order.domain.mock.Customer;
 import dau.azit.simon.order.domain.mock.Product;
 import dau.azit.simon.order.dto.OrderDto;
 import dau.azit.simon.order.repository.OrderRepository;
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
+@Service
 @Transactional(readOnly = true)
 public class OrderService {
 	private final OrderRepository orderRepository;
+	private final CustomerService customerService;
 
 	public Order createAdditionalOrder(OrderDto.CreateAdditionalOrderDto dto) {
 		//TODO : 실제 Customer 클래스로 수정 필요
@@ -32,6 +38,28 @@ public class OrderService {
 		Order order = Order.createOrder(orderLines, customer, dto.memo().orElse(null));
 
 		return orderRepository.save(order);
+	}
+
+
+	@Transactional
+	public Order createFirstOrder(OrderDto.CreateFirstOrderDto dto) {
+		if (dto.customer() == null || dto.orderLines() == null) {
+			throw new IllegalArgumentException("customer or orderLines is null");
+		}
+
+		Customer customer = customerService.createCustomer(dto.customer());
+		List<OrderLine> orderLines = dto.orderLines().stream()
+				.map(orderLineDto -> {
+					//TODO : 실제 Product 클래스로 수정 필요
+					Product product = new Product();
+					return new OrderLine(product, orderLineDto.quantity());
+				})
+				.collect(Collectors.toList());
+//
+		Order order = Order.createOrder(orderLines, customer, dto.memo().orElse(null));
+
+		return orderRepository.save(order);
+//	}
 	}
 
 

--- a/src/main/java/dau/azit/simon/order/service/OrderService.java
+++ b/src/main/java/dau/azit/simon/order/service/OrderService.java
@@ -38,27 +38,5 @@ public class OrderService {
 
 		orderRepository.save(order);
 	}
-
-
-	@Transactional
-	public SalesOrder createFirstOrder(OrderDto.CreateFirstOrderDto dto) {
-		if (dto.customer() == null || dto.orderLines() == null) {
-			throw new IllegalArgumentException("customer or orderLines is null");
-		}
-
-		Customer customer = customerService.createCustomer(dto.customer());
-		List<OrderLine> orderLines = dto.orderLines().stream()
-				.map(orderLineDto -> {
-					//TODO : 실제 Product 클래스로 수정 필요
-					Product product = new Product();
-					return new OrderLine(product, orderLineDto.quantity());
-				})
-				.collect(Collectors.toList());
-		SalesOrder order = SalesOrder.createOrder(orderLines, customer, dto.orderStatus(), dto.memo().orElse(null));
-
-		orderRepository.save(order);
-		return order;
-	}
-
-
+	
 }

--- a/src/main/java/dau/azit/simon/order/service/OrderService.java
+++ b/src/main/java/dau/azit/simon/order/service/OrderService.java
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
 public class OrderService {
 	private final OrderRepository orderRepository;
 
-	public Order createOrder(OrderDto.CreateOrderDto dto) {
+	public Order createAdditionalOrder(OrderDto.CreateAdditionalOrderDto dto) {
 		//TODO : 실제 Customer 클래스로 수정 필요
 		Customer customer = new Customer();
 
@@ -34,21 +34,5 @@ public class OrderService {
 		return orderRepository.save(order);
 	}
 
-	public Order createEstimation(OrderDto.CreateOrderDto dto) {
-		//TODO : 실제 Customer 클래스로 수정 필요
-		Customer customer = new Customer();
-
-		List<OrderLine> orderLines = dto.orderLines().stream()
-				.map(orderLineDto -> {
-					//TODO : 실제 Product 클래스로 수정 필요
-					Product product = new Product();
-					return new OrderLine(product, orderLineDto.quantity());
-				})
-				.collect(Collectors.toList());
-
-		Order order = Order.createEstimation(orderLines, customer, dto.memo().orElse(null));
-
-		return orderRepository.save(order);
-	}
 
 }

--- a/src/main/java/dau/azit/simon/order/service/OrderService.java
+++ b/src/main/java/dau/azit/simon/order/service/OrderService.java
@@ -1,12 +1,54 @@
 package dau.azit.simon.order.service;
 
+import dau.azit.simon.order.domain.Order;
+import dau.azit.simon.order.domain.OrderLine;
+import dau.azit.simon.order.domain.mock.Customer;
+import dau.azit.simon.order.domain.mock.Product;
+import dau.azit.simon.order.dto.OrderDto;
 import dau.azit.simon.order.repository.OrderRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class OrderService {
 	private final OrderRepository orderRepository;
+
+	public Order createOrder(OrderDto.CreateOrderDto dto) {
+		//TODO : 실제 Customer 클래스로 수정 필요
+		Customer customer = new Customer();
+
+		List<OrderLine> orderLines = dto.orderLines().stream()
+				.map(orderLineDto -> {
+					//TODO : 실제 Product 클래스로 수정 필요
+					Product product = new Product();
+					return new OrderLine(product, orderLineDto.getQuantity());
+				})
+				.collect(Collectors.toList());
+
+		Order order = Order.createOrder(orderLines, customer, dto.memo().orElse(null));
+
+		return orderRepository.save(order);
+	}
+
+	public Order createEstimation(OrderDto.CreateOrderDto dto) {
+		//TODO : 실제 Customer 클래스로 수정 필요
+		Customer customer = new Customer();
+
+		List<OrderLine> orderLines = dto.orderLines().stream()
+				.map(orderLineDto -> {
+					//TODO : 실제 Product 클래스로 수정 필요
+					Product product = new Product();
+					return new OrderLine(product, orderLineDto.getQuantity());
+				})
+				.collect(Collectors.toList());
+
+		Order order = Order.createEstimation(orderLines, customer, dto.memo().orElse(null));
+
+		return orderRepository.save(order);
+	}
 
 }

--- a/src/main/java/dau/azit/simon/order/service/OrderService.java
+++ b/src/main/java/dau/azit/simon/order/service/OrderService.java
@@ -2,7 +2,7 @@ package dau.azit.simon.order.service;
 
 import dau.azit.simon.customer.domain.Customer;
 import dau.azit.simon.customer.service.CustomerService;
-import dau.azit.simon.order.domain.Order;
+import dau.azit.simon.order.domain.SalesOrder;
 import dau.azit.simon.order.domain.OrderLine;
 import dau.azit.simon.order.domain.mock.Product;
 import dau.azit.simon.order.dto.OrderDto;
@@ -34,14 +34,14 @@ public class OrderService {
 				})
 				.collect(Collectors.toList());
 
-		Order order = Order.createOrder(orderLines, customer, dto.orderStatus(), dto.memo().orElse(null));
+		SalesOrder order = SalesOrder.createOrder(orderLines, customer, dto.orderStatus(), dto.memo().orElse(null));
 
 		orderRepository.save(order);
 	}
 
 
 	@Transactional
-	public Order createFirstOrder(OrderDto.CreateFirstOrderDto dto) {
+	public SalesOrder createFirstOrder(OrderDto.CreateFirstOrderDto dto) {
 		if (dto.customer() == null || dto.orderLines() == null) {
 			throw new IllegalArgumentException("customer or orderLines is null");
 		}
@@ -54,7 +54,7 @@ public class OrderService {
 					return new OrderLine(product, orderLineDto.quantity());
 				})
 				.collect(Collectors.toList());
-		Order order = Order.createOrder(orderLines, customer, dto.orderStatus(), dto.memo().orElse(null));
+		SalesOrder order = SalesOrder.createOrder(orderLines, customer, dto.orderStatus(), dto.memo().orElse(null));
 
 		orderRepository.save(order);
 		return order;

--- a/src/main/java/dau/azit/simon/order/service/OrderService.java
+++ b/src/main/java/dau/azit/simon/order/service/OrderService.java
@@ -1,0 +1,12 @@
+package dau.azit.simon.order.service;
+
+import dau.azit.simon.order.repository.OrderRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class OrderService {
+	private final OrderRepository orderRepository;
+
+}

--- a/src/main/java/dau/azit/simon/order/service/OrderService.java
+++ b/src/main/java/dau/azit/simon/order/service/OrderService.java
@@ -21,9 +21,10 @@ public class OrderService {
 	private final OrderRepository orderRepository;
 	private final CustomerService customerService;
 
-	public Order createAdditionalOrder(OrderDto.CreateAdditionalOrderDto dto) {
-		//TODO : 실제 Customer 클래스로 수정 필요
-		Customer customer = new Customer();
+	@Transactional
+	public void createAdditionalOrder(OrderDto.CreateAdditionalOrderDto dto) {
+
+		Customer customer = customerService.findCustomerById(dto.customerId());
 
 		List<OrderLine> orderLines = dto.orderLines().stream()
 				.map(orderLineDto -> {
@@ -35,7 +36,7 @@ public class OrderService {
 
 		Order order = Order.createOrder(orderLines, customer, dto.orderStatus(), dto.memo().orElse(null));
 
-		return orderRepository.save(order);
+		orderRepository.save(order);
 	}
 
 
@@ -53,11 +54,10 @@ public class OrderService {
 					return new OrderLine(product, orderLineDto.quantity());
 				})
 				.collect(Collectors.toList());
-//
 		Order order = Order.createOrder(orderLines, customer, dto.orderStatus(), dto.memo().orElse(null));
 
-		return orderRepository.save(order);
-//	}
+		orderRepository.save(order);
+		return order;
 	}
 
 

--- a/src/main/java/dau/azit/simon/order/service/OrderService.java
+++ b/src/main/java/dau/azit/simon/order/service/OrderService.java
@@ -25,7 +25,7 @@ public class OrderService {
 				.map(orderLineDto -> {
 					//TODO : 실제 Product 클래스로 수정 필요
 					Product product = new Product();
-					return new OrderLine(product, orderLineDto.getQuantity());
+					return new OrderLine(product, orderLineDto.quantity());
 				})
 				.collect(Collectors.toList());
 
@@ -42,7 +42,7 @@ public class OrderService {
 				.map(orderLineDto -> {
 					//TODO : 실제 Product 클래스로 수정 필요
 					Product product = new Product();
-					return new OrderLine(product, orderLineDto.getQuantity());
+					return new OrderLine(product, orderLineDto.quantity());
 				})
 				.collect(Collectors.toList());
 


### PR DESCRIPTION
이전에 잘못 PR된 부분을 한번 통합하기 위해 여러 기능들을 한번에 PR함.
- customer 엔티티 구현
- customer의 service, controller, repository 레이어 기본 골격 구현.
- customer 생성하는 createCustomer로직 구현
- customer 찾는 findCustomerById 구현
- order의 첫번째 주문 과 이후 주문 기능을 분리해서 구현(dto와 service, controller등도 분리)

related issue : #8 #11 #14